### PR TITLE
Fix error in .podspec file

### DIFF
--- a/SwiftSafe.podspec
+++ b/SwiftSafe.podspec
@@ -2,10 +2,10 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftSafe"
-  s.version      = "0.1"
+  s.version      = "2.0.0"
   s.summary      = "Thread synchronization made easy."
 
-  s.homepage     = "https://github.com/czechboy0/SwiftSafe"
+  s.homepage     = "https://github.com/nodes-ios/SwiftSafe"
   s.license      = { :type => "MIT", :file => "LICENSE" }
 
   s.author             = { "Honza Dvorsky" => "https://honzadvorsky.com" }
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
 
-  s.source       = { :git => "https://github.com/czechboy0/SwiftSafe.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/nodes-ios/SwiftSafe.git", :tag => "#{s.version}" }
 
   s.source_files  = "Safe/*.swift"
 


### PR DESCRIPTION
The `.podspec` repository was outdated using the old references to the repository of @czechboy0 that doesn't exist anymore and that implies that all the dependencies using this repository fails in `pod install`.

The following issues were solved in this pull request:
1. Fix the source of the repository. 
2. Fix the issue with the prefix `v` in the tag version.

The validation using  `pod spec lint` was correct. Nevertheless before run `pod spec lint` to validate the specs I recommend read this [issue](https://github.com/CocoaPods/CocoaPods/pull/5989) regarding Swift 3.0 validation specs. 

Also it would be great if the pull request is merged please update the Specs repository in CocoaPods using `pod trunk push [XXX.podspec]` because the last version submitted is `0.1` and does not exist anymore.
